### PR TITLE
Fix missing entitlements for executing the deno_core environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snip",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Snip",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "io.github.snip-editor.snip",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -31,7 +31,8 @@
       "resources/scripts/commands/**/*"
     ],
     "macOS": {
-      "signingIdentity": "78305F70842FCB238E12B6283CA03A027BA0E815"
+      "signingIdentity": "78305F70842FCB238E12B6283CA03A027BA0E815",
+      "entitlements": "./Entitlements.plist"
     }
   }
 }


### PR DESCRIPTION
Without the entitlements, we will receive an out of memory, since we are not allowed to allocate memory that can be executed, which means the v8 jit won't run