### PR TITLE
Cross platform support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,14 +17,19 @@ jobs:
         include:
           - platform: 'macos-latest' # for universal binary.
             args: '--target universal-apple-darwin'
-    #          - platform: 'macos-latest' # for Arm based macs (M1 and above).
-    #            args: '--target aarch64-apple-darwin'
-    #          - platform: 'macos-latest' # for Intel based macs.
-    #            args: '--target x86_64-apple-darwin'
-    #          - platform: 'ubuntu-22.04'
-    #            args: ''
-    #          - platform: 'windows-latest'
-    #            args: ''
+            targets: 'aarch64-apple-darwin,x86_64-apple-darwin'
+          - platform: 'windows-latest' # x86.
+            args: '--target i686-pc-windows-msvc --bundles msi'
+            targets: 'i686-pc-windows-msvc'
+          - platform: 'windows-latest' # x64.
+            args: '--target x86_64-pc-windows-msvc --bundles msi'
+            targets: 'x86_64-pc-windows-msvc'
+          - platform: 'ubuntu-22.04'
+            args: ''
+            targets: ''
+          - platform: '	ubuntu-24.04-arm'
+            args: ''
+            targets: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -45,7 +50,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.args }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Snip is a simple, cross-platform text editor inspired by Boop. It aims to improv
 
 ## Features
 
-- **Cross-Platform Support**: Available on macOS, Windows[^1], and Linux[^1].
+- **Cross-Platform Support**: Available on macOS, Windows, and Linux.
 - **Handling of Large Files**: Efficiently handles large files without performance degradation.
 - **Syntax Highlighting**: Syntax highlighting for various programming languages.
-- **File Operations[^1]**: Ability to open, edit, and save files.
+- **File Operations**[^1]: Ability to open, edit, and save files.
 - **Easy Scripting**: Simple and powerful scripting capabilities.
 - **Quick Startup**: Fast startup time, making it ideal for quick edits.
 - **Notepad Functionality**: Useful as a small notepad for copying and editing snippets.
@@ -30,15 +30,29 @@ Download the .dmg from the [releases page](https://github.com/SnipEditor/snip/re
 
 ### Windows
 
-TODO: Currently windows support is not yet implemented. Support will arrive in the near future
+Download the .msi for your cpu architecture from the [releases page](https://github.com/SnipEditor/snip/releases). Open it and follow the installation instructions.
 
 ### Linux
 
-TODO: Currently linux support is not yet implemented. Support will arrive in the near future
+#### Debian-based operating systems
+
+Download the .deb for your cpu architecture from the [releases page](https://github.com/SnipEditor/snip/releases).
+Run the following command with `<file>` replaced with the path to the downloaded .deb file:
+```bash
+sudo dpkg -i <file>
+```
+
+#### Red Hat based operating systems
+
+Download the .rpm for your cpu architecture from the [releases page](https://github.com/SnipEditor/snip/releases).
+Run the following command with `<file>` replaced with the path to the downloaded .rpm file:
+```bash
+sudo rpm -i <file>
+```
 
 ## Usage
 
-To start Snip, simply run the binary
+To start Snip, simply run it from your application list
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Download the .msi for your cpu architecture from the [releases page](https://git
 
 Download the .deb for your cpu architecture from the [releases page](https://github.com/SnipEditor/snip/releases).
 Run the following command with `<file>` replaced with the path to the downloaded .deb file:
+
 ```bash
 sudo dpkg -i <file>
 ```
@@ -46,6 +47,7 @@ sudo dpkg -i <file>
 
 Download the .rpm for your cpu architecture from the [releases page](https://github.com/SnipEditor/snip/releases).
 Run the following command with `<file>` replaced with the path to the downloaded .rpm file:
+
 ```bash
 sudo rpm -i <file>
 ```

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,11 +62,11 @@ pub fn run() {
             app.manage(Mutex::new(script_manager));
 
             let app_handle = app.handle().clone();
-            app.listen_any("open_settings", move |event| {
+            app.listen_any("open_settings", move |_| {
                 open_settings_window(&app_handle);
             });
             let app_handle = app.handle().clone();
-            app.listen_any("new_window", move |event| {
+            app.listen_any("new_window", move |_| {
                 let app_handle = app_handle.clone();
                 spawn(async move {
                     let windows: State<'_, Mutex<Windows>> = app_handle.state();
@@ -88,8 +88,7 @@ pub fn run() {
                 }
             }
             WindowEvent::Focused(true) => {
-                // setup_menu(window.app_handle(), window.label() == "settings")
-                //     .expect("Could not replace menu");
+                menu::on_window_focus_change(window);
             }
             _ => {}
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,9 @@ mod window;
 
 use crate::scripts::commands::{get_script_commands, reply_editor_request, run_script_command};
 use crate::scripts::loader::scripts::ScriptManager;
-use crate::settings::{get_settings, open_settings_window, set_preferred_language, set_theme, set_wrap_lines, Settings};
+use crate::settings::{
+    get_settings, open_settings_window, set_preferred_language, set_theme, set_wrap_lines, Settings,
+};
 use crate::window::{menu, Windows};
 use tauri::async_runtime::{spawn, Mutex};
 use tauri::path::BaseDirectory;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -4,6 +4,7 @@ use tauri::async_runtime::Mutex;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri::Error::WebviewLabelAlreadyExists;
 use tauri_plugin_store::StoreExt;
+use crate::window::menu;
 
 #[derive(Serialize, Deserialize, Clone)]
 enum Theme {
@@ -99,7 +100,8 @@ pub fn open_settings_window(app: &AppHandle) {
         "settings".to_string(),
         WebviewUrl::App("windows/settings.html".parse().unwrap()),
     )
-        .min_inner_size(200.0, 400.0)
+        .inner_size(400.0, 250.0)
+        .resizable(false)
         .title("Snip Settings")
         .build();
     if let Err(WebviewLabelAlreadyExists(_)) = settings_window_result {
@@ -108,5 +110,8 @@ pub fn open_settings_window(app: &AppHandle) {
         settings_window.unminimize().unwrap(); // Must use it if window is minimized
         settings_window.set_focus().unwrap();
         settings_window.show().unwrap();
+    } else {
+        let window = settings_window_result.unwrap();
+        menu::on_new_window(&window);
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,10 +1,10 @@
+use crate::window::menu;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 use tauri::async_runtime::Mutex;
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri::Error::WebviewLabelAlreadyExists;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_store::StoreExt;
-use crate::window::menu;
 
 #[derive(Serialize, Deserialize, Clone)]
 enum Theme {
@@ -100,10 +100,10 @@ pub fn open_settings_window(app: &AppHandle) {
         "settings".to_string(),
         WebviewUrl::App("windows/settings.html".parse().unwrap()),
     )
-        .inner_size(400.0, 250.0)
-        .resizable(false)
-        .title("Snip Settings")
-        .build();
+    .inner_size(400.0, 250.0)
+    .resizable(false)
+    .title("Snip Settings")
+    .build();
     if let Err(WebviewLabelAlreadyExists(_)) = settings_window_result {
         let webview_windows = app.webview_windows();
         let settings_window = webview_windows.get("settings").unwrap();

--- a/src-tauri/src/window/menu.rs
+++ b/src-tauri/src/window/menu.rs
@@ -1,0 +1,43 @@
+use tauri::{AppHandle, Emitter, Manager, State, Window};
+use tauri::menu::MenuEvent;
+use tokio::sync::Mutex;
+use crate::settings::open_settings_window;
+use crate::window::Windows;
+
+const MENU_ITEM_ID_SETTINGS: &str = "settings";
+const MENU_ITEM_ID_NEW_WINDOW: &str = "window_new";
+const MENU_ITEM_ID_SCRIPTS_OPEN_PICKER: &str = "scripts_open_picker";
+const MENU_ITEM_ID_SCRIPTS_REEXECUTE_LAST: &str = "scripts_reexecute_last";
+
+fn handle_menu_event(app: &AppHandle, window: &Window, event: MenuEvent) {
+    match event.id().0.as_str() {
+        MENU_ITEM_ID_SETTINGS => {
+            open_settings_window(app);
+        }
+        MENU_ITEM_ID_SCRIPTS_OPEN_PICKER => {
+            app.emit_to(window.label(), "open_picker", true)
+                .unwrap()
+        }
+        MENU_ITEM_ID_NEW_WINDOW => {
+            let windows: State<'_, Mutex<Windows>> = app.state();
+            let mut windows = windows.blocking_lock();
+            windows.create_window(app).unwrap();
+        }
+        _ => {}
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn initialize_global_handlers(app: &AppHandle) {
+    app.on_menu_event(move |app, event| {
+        let focused_window = app.get_focused_window();
+        if let Some(focused_window) = focused_window {
+            handle_menu_event(app, &focused_window, event);
+        } else {
+            println!("Warning: No window in focus, ignoring menu event");
+        }
+    });
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn initialize_global_handlers(app: &AppHandle) {}

--- a/src-tauri/src/window/menu.rs
+++ b/src-tauri/src/window/menu.rs
@@ -25,7 +25,9 @@ fn build_menu(app: &AppHandle, in_settings: bool) -> Result<Menu<tauri::Wry>, ta
         .accelerator("CmdOrCtrl+,")
         .enabled(!in_settings)
         .build(app)?;
-    let app_sub_menu_builder = SubmenuBuilder::new(app, "Snip")
+
+    #[allow(unused_mut)] // mut is needed on macOS
+    let mut app_sub_menu_builder = SubmenuBuilder::new(app, "Snip")
         .about(Some(
             AboutMetadataBuilder::new()
                 .name(Some("Snip"))
@@ -141,7 +143,7 @@ pub fn on_new_window(_window: &WebviewWindow) {}
 
 #[cfg(target_os = "macos")]
 pub fn on_window_focus_change(window: &Window) {
-    (||{
+    (|| -> Result<(), tauri::Error> {
         let menu = build_menu(window.app_handle(), window.label() == "settings")?;
         menu.set_as_app_menu()?;
         Ok(())

--- a/src-tauri/src/window/menu.rs
+++ b/src-tauri/src/window/menu.rs
@@ -1,11 +1,12 @@
+use tauri::menu::{
+    AboutMetadataBuilder, Menu, MenuEvent, MenuItemBuilder, Submenu, SubmenuBuilder,
+};
 use tauri::{AppHandle, Emitter, Manager, WebviewWindow, Window, Wry};
-use tauri::menu::{AboutMetadataBuilder, Menu, MenuEvent, MenuItemBuilder, Submenu, SubmenuBuilder};
 
 const MENU_ITEM_ID_SETTINGS: &str = "settings";
 const MENU_ITEM_ID_NEW_WINDOW: &str = "window_new";
 const MENU_ITEM_ID_SCRIPTS_OPEN_PICKER: &str = "scripts_open_picker";
 const MENU_ITEM_ID_SCRIPTS_REEXECUTE_LAST: &str = "scripts_reexecute_last";
-
 
 fn get_file_sub_menu(app: &AppHandle, in_settings: bool) -> Result<Submenu<Wry>, tauri::Error> {
     let mut builder = SubmenuBuilder::new(app, "File");
@@ -41,7 +42,8 @@ fn build_menu(app: &AppHandle, in_settings: bool) -> Result<Menu<tauri::Wry>, ta
 
     #[cfg(target_os = "macos")]
     {
-        app_sub_menu_builder = app_sub_menu_builder.services()
+        app_sub_menu_builder = app_sub_menu_builder
+            .services()
             .separator()
             .hide()
             .hide_others()
@@ -49,8 +51,7 @@ fn build_menu(app: &AppHandle, in_settings: bool) -> Result<Menu<tauri::Wry>, ta
             .separator();
     }
 
-    let app_sub_menu = app_sub_menu_builder.quit()
-        .build()?;
+    let app_sub_menu = app_sub_menu_builder.quit().build()?;
 
     let file_sub_menu = get_file_sub_menu(app, in_settings)?;
     let app_menu = Menu::new(app)?;
@@ -99,12 +100,10 @@ fn handle_menu_event(app: &AppHandle, window: &Window, event: MenuEvent) {
             app.emit("open_settings", true).unwrap();
         }
         MENU_ITEM_ID_SCRIPTS_OPEN_PICKER => {
-            app.emit_to(window.label(), "open_picker", true)
-                .unwrap()
+            app.emit_to(window.label(), "open_picker", true).unwrap()
         }
         MENU_ITEM_ID_NEW_WINDOW => {
             app.emit("new_window", true).unwrap();
-
         }
         _ => {}
     }
@@ -150,7 +149,8 @@ pub fn on_window_focus_change(window: &Window) {
         let menu = build_menu(window.app_handle(), window.label() == "settings")?;
         menu.set_as_app_menu()?;
         Ok(())
-    })().expect("Could not replace menu");
+    })()
+    .expect("Could not replace menu");
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/src-tauri/src/window/menu.rs
+++ b/src-tauri/src/window/menu.rs
@@ -110,7 +110,7 @@ fn handle_menu_event(app: &AppHandle, window: &Window, event: MenuEvent) {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(not(target_os = "windows"))]
 pub fn initialize_global_handlers(app: &AppHandle) {
     app.on_menu_event(move |app, event| {
         let focused_window = app.get_focused_window();
@@ -122,7 +122,7 @@ pub fn initialize_global_handlers(app: &AppHandle) {
     });
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
 pub fn initialize_global_handlers(_app: &AppHandle) {}
 
 #[cfg(not(target_os = "macos"))]
@@ -130,9 +130,12 @@ pub fn on_new_window(window: &WebviewWindow) {
     if window.label() == "settings" {
         return;
     }
-    window.on_menu_event(|window, event| {
-        handle_menu_event(window.app_handle(), window, event);
-    });
+    #[cfg(target_os = "windows")]
+    {
+        window.on_menu_event(|window, event| {
+            handle_menu_event(window.app_handle(), window, event);
+        });
+    }
 
     let menu = build_menu(window.app_handle(), false).unwrap();
     window.set_menu(menu).unwrap();

--- a/src-tauri/src/window/menu.rs
+++ b/src-tauri/src/window/menu.rs
@@ -125,13 +125,28 @@ pub fn initialize_global_handlers(_app: &AppHandle) {}
 
 #[cfg(not(target_os = "macos"))]
 pub fn on_new_window(window: &WebviewWindow) {
+    if window.label() == "settings" {
+        return;
+    }
     window.on_menu_event(|window, event| {
         handle_menu_event(window.app_handle(), window, event);
     });
 
-    let menu = build_menu(window.app_handle(), window.label() == "settings").unwrap();
+    let menu = build_menu(window.app_handle(), false).unwrap();
     window.set_menu(menu).unwrap();
 }
 
 #[cfg(target_os = "macos")]
 pub fn on_new_window(_window: &WebviewWindow) {}
+
+#[cfg(target_os = "macos")]
+pub fn on_window_focus_change(window: &Window) {
+    (||{
+        let menu = build_menu(window.app_handle(), window.label() == "settings")?;
+        menu.set_as_app_menu()?;
+        Ok(())
+    })().expect("Could not replace menu");
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn on_window_focus_change(_window: &Window) {}

--- a/src-tauri/src/window/menu.rs
+++ b/src-tauri/src/window/menu.rs
@@ -1,27 +1,108 @@
-use tauri::{AppHandle, Emitter, Manager, State, Window};
-use tauri::menu::MenuEvent;
-use tokio::sync::Mutex;
-use crate::settings::open_settings_window;
-use crate::window::Windows;
+use tauri::{AppHandle, Emitter, Manager, WebviewWindow, Window, Wry};
+use tauri::menu::{AboutMetadataBuilder, Menu, MenuEvent, MenuItemBuilder, Submenu, SubmenuBuilder};
 
 const MENU_ITEM_ID_SETTINGS: &str = "settings";
 const MENU_ITEM_ID_NEW_WINDOW: &str = "window_new";
 const MENU_ITEM_ID_SCRIPTS_OPEN_PICKER: &str = "scripts_open_picker";
 const MENU_ITEM_ID_SCRIPTS_REEXECUTE_LAST: &str = "scripts_reexecute_last";
 
+
+fn get_file_sub_menu(app: &AppHandle, in_settings: bool) -> Result<Submenu<Wry>, tauri::Error> {
+    let mut builder = SubmenuBuilder::new(app, "File");
+    if !in_settings {
+        let new_window_item = MenuItemBuilder::new("New Window")
+            .id(MENU_ITEM_ID_NEW_WINDOW)
+            .accelerator("CmdOrCtrl+N")
+            .build(app)?;
+        builder = builder.item(&new_window_item).separator();
+    }
+    builder.close_window().build()
+}
+
+fn build_menu(app: &AppHandle, in_settings: bool) -> Result<Menu<tauri::Wry>, tauri::Error> {
+    let settings = MenuItemBuilder::new("Settings...")
+        .id(MENU_ITEM_ID_SETTINGS)
+        .accelerator("CmdOrCtrl+,")
+        .enabled(!in_settings)
+        .build(app)?;
+    let app_sub_menu_builder = SubmenuBuilder::new(app, "Snip")
+        .about(Some(
+            AboutMetadataBuilder::new()
+                .name(Some("Snip"))
+                .comments(Some("A simple text editor for quickly editing snippets"))
+                .authors(Some(vec!["Rob Bogie".parse().unwrap()]))
+                .build(),
+        ))
+        .separator()
+        .item(&settings)
+        .separator();
+
+    #[cfg(target_os = "macos")]
+    {
+        app_sub_menu_builder = app_sub_menu_builder.services()
+            .separator()
+            .hide()
+            .hide_others()
+            .show_all()
+            .separator();
+    }
+
+    let app_sub_menu = app_sub_menu_builder.quit()
+        .build()?;
+
+    let file_sub_menu = get_file_sub_menu(app, in_settings)?;
+    let app_menu = Menu::new(app)?;
+
+    if !in_settings {
+        let edit_sub_menu = SubmenuBuilder::new(app, "Edit")
+            .undo()
+            .redo()
+            .separator()
+            .cut()
+            .copy()
+            .paste()
+            .select_all()
+            .build()?;
+
+        let open_script_picker_item = MenuItemBuilder::new("Open Picker")
+            .id(MENU_ITEM_ID_SCRIPTS_OPEN_PICKER)
+            .accelerator("CmdOrCtrl+B")
+            .build(app)?;
+        let reexecute_last_script_item = MenuItemBuilder::new("Re-execute Last Script")
+            .id(MENU_ITEM_ID_SCRIPTS_REEXECUTE_LAST)
+            .accelerator("CmdOrCtrl+Shift+B")
+            .enabled(false)
+            .build(app)?;
+        let scripts_sub_menu = SubmenuBuilder::new(app, "Scripts")
+            .item(&open_script_picker_item)
+            .separator()
+            .item(&reexecute_last_script_item)
+            .build()?;
+        app_menu.append_items(&[
+            &app_sub_menu,
+            &file_sub_menu,
+            &edit_sub_menu,
+            &scripts_sub_menu,
+        ])?;
+    } else {
+        app_menu.append_items(&[&app_sub_menu, &file_sub_menu])?;
+    }
+
+    Ok(app_menu)
+}
+
 fn handle_menu_event(app: &AppHandle, window: &Window, event: MenuEvent) {
     match event.id().0.as_str() {
         MENU_ITEM_ID_SETTINGS => {
-            open_settings_window(app);
+            app.emit("open_settings", true).unwrap();
         }
         MENU_ITEM_ID_SCRIPTS_OPEN_PICKER => {
             app.emit_to(window.label(), "open_picker", true)
                 .unwrap()
         }
         MENU_ITEM_ID_NEW_WINDOW => {
-            let windows: State<'_, Mutex<Windows>> = app.state();
-            let mut windows = windows.blocking_lock();
-            windows.create_window(app).unwrap();
+            app.emit("new_window", true).unwrap();
+
         }
         _ => {}
     }
@@ -40,4 +121,17 @@ pub fn initialize_global_handlers(app: &AppHandle) {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn initialize_global_handlers(app: &AppHandle) {}
+pub fn initialize_global_handlers(_app: &AppHandle) {}
+
+#[cfg(not(target_os = "macos"))]
+pub fn on_new_window(window: &WebviewWindow) {
+    window.on_menu_event(|window, event| {
+        handle_menu_event(window.app_handle(), window, event);
+    });
+
+    let menu = build_menu(window.app_handle(), window.label() == "settings").unwrap();
+    window.set_menu(menu).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+pub fn on_new_window(_window: &WebviewWindow) {}

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -72,7 +72,7 @@ impl Windows {
             },
         );
 
-        WebviewWindowBuilder::new(
+        let window = WebviewWindowBuilder::new(
             app_handle,
             id,
             WebviewUrl::App("windows/index.html".parse().unwrap()),
@@ -80,6 +80,8 @@ impl Windows {
         .min_inner_size(800.0, 600.0)
         .title(format!("Snip - Untitled {}", self.last_window_id))
         .build()?;
+
+        menu::on_new_window(&window);
 
         Ok(())
     }

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -1,3 +1,5 @@
+pub mod menu;
+
 use crate::scripts::commands::{handle_script_task, ScriptTask, WindowScriptState};
 use std::collections::HashMap;
 use std::thread;

--- a/src/entrypoints/main_window.tsx
+++ b/src/entrypoints/main_window.tsx
@@ -3,6 +3,27 @@ import ReactDOM from 'react-dom/client'
 import CodeEditor from '../containers/CodeEditor.tsx'
 import SettingsProvider from '../components/SettingsProvider.tsx'
 import GlobalThemeDataSwitcher from '../components/GlobalThemeDataSwitcher.tsx'
+import { emit } from '@tauri-apps/api/event'
+import { platform } from '@tauri-apps/plugin-os'
+
+if(platform() === 'windows') {
+  document.addEventListener('keydown', (e) => {
+    if (!e.ctrlKey) {
+      return
+    }
+    switch(e.key) {
+      case 'n':
+        void emit('new_window', true)
+        break
+      case ',':
+        void emit('open_settings', true)
+        break
+      case 'b':
+        void emit('open_picker', true)
+        break
+    }
+  })
+}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/entrypoints/main_window.tsx
+++ b/src/entrypoints/main_window.tsx
@@ -12,7 +12,7 @@ if (platform() === 'windows') {
     if (!e.ctrlKey) {
       return
     }
-    switch(e.key) {
+    switch (e.key) {
       case 'n':
         void emit('new_window', true)
         break

--- a/src/entrypoints/main_window.tsx
+++ b/src/entrypoints/main_window.tsx
@@ -3,10 +3,11 @@ import ReactDOM from 'react-dom/client'
 import CodeEditor from '../containers/CodeEditor.tsx'
 import SettingsProvider from '../components/SettingsProvider.tsx'
 import GlobalThemeDataSwitcher from '../components/GlobalThemeDataSwitcher.tsx'
-import { emit } from '@tauri-apps/api/event'
+import { emit, emitTo } from '@tauri-apps/api/event'
 import { platform } from '@tauri-apps/plugin-os'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 
-if(platform() === 'windows') {
+if (platform() === 'windows') {
   document.addEventListener('keydown', (e) => {
     if (!e.ctrlKey) {
       return
@@ -19,7 +20,7 @@ if(platform() === 'windows') {
         void emit('open_settings', true)
         break
       case 'b':
-        void emit('open_picker', true)
+        void emitTo(getCurrentWindow().label, 'open_picker', true)
         break
     }
   })


### PR DESCRIPTION
Add support for windows and linux. 

The menu is refactored to support the single global menu on macos, and window specific menus on linux and windows. On linux the global event handler is used since every window is receiving the same events