### PR TITLE
Remove the linux arm64 build since the github runners take too long

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,6 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: ''
             targets: ''
-          - platform: '	ubuntu-24.04-arm'
-            args: ''
-            targets: ''
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Currently the queues are too full, making releases run too long, since the arm build will keep waiting in the queue